### PR TITLE
Fix #225 store resolve bug

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -33,13 +33,13 @@
     "sidebar_action": {
         "default_title": "Feeds",
         "default_panel": "/sidebar/sidebar.html",
-        "default_icon": "test.svg",
+        "default_icon": "rss.svg",
         "browser_style": true
     },
 
     "browser_action": {
         "browser_style": true,
-        "default_icon": "test.svg",
+        "default_icon": "rss.svg",
         "default_title": "Feeds"
     }
 }

--- a/src/store/reduxBridge/createProxyStore.ts
+++ b/src/store/reduxBridge/createProxyStore.ts
@@ -22,11 +22,14 @@ export function createProxyStore(): { storePromise: Promise<Store<RootState>> } 
     // get full state on init
     sendMessageToBackgroundScript({ type: MessageType.GetFullStateRequest })
         .then((result) => {
+            if (result === undefined) {
+                return;
+            }
             processMessage(result);
             // messaging is established
             resolveStore();
         })
-        .catch((reason) => console.error(`Error sending message, reason: ${reason}`));
+        .catch((reason) => console.error(`Error sending message, reason: ${reason.message}`));
 
     function processMessage(message: BackgroundScriptMessage) {
         const type = message.type;
@@ -34,6 +37,7 @@ export function createProxyStore(): { storePromise: Promise<Store<RootState>> } 
         switch (type) {
             case MessageType.GetFullStateResponse:
                 replaceState(message.payload);
+                resolveStore(); // TODO mr nur einmalig machen?
                 break;
 
             case MessageType.PatchState:

--- a/src/store/reduxBridge/createProxyStore.ts
+++ b/src/store/reduxBridge/createProxyStore.ts
@@ -20,24 +20,16 @@ export function createProxyStore(): { storePromise: Promise<Store<RootState>> } 
     });
 
     // get full state on init
-    sendMessageToBackgroundScript({ type: MessageType.GetFullStateRequest })
-        .then((result) => {
-            if (result === undefined) {
-                return;
-            }
-            processMessage(result);
-            // messaging is established
-            resolveStore();
-        })
-        .catch((reason) => console.error(`Error sending message, reason: ${reason.message}`));
+    sendMessageToBackgroundScript({ type: MessageType.GetFullStateRequest });
 
     function processMessage(message: BackgroundScriptMessage) {
         const type = message.type;
 
         switch (type) {
             case MessageType.GetFullStateResponse:
+                // init of extension or background-scrip re-initialized
                 replaceState(message.payload);
-                resolveStore(); // TODO mr nur einmalig machen?
+                resolveStore();
                 break;
 
             case MessageType.PatchState:

--- a/src/store/reduxBridge/wrapStore.ts
+++ b/src/store/reduxBridge/wrapStore.ts
@@ -34,10 +34,11 @@ export const wrapStore = (store: Store, messages: ContenScriptMessage[]) => {
         switch (type) {
             case MessageType.GetFullStateRequest:
                 // Provide state for content-script initialization
-                return Promise.resolve({
+                sendMessageToContentScripts({
                     type: MessageType.GetFullStateResponse,
                     payload: store.getState(),
                 });
+                break;
 
             case MessageType.DispatchAction:
                 // Forward dispatch from content-script


### PR DESCRIPTION
When Background Script is suspended while sidebar is reloaded (switched from bookmark or opened) init is not working properly because the store is not resolved in time.

See #225 

also send message instead of returning a promise
```
         sendMessageToContentScripts({
                    type: MessageType.GetFullStateResponse,
                    payload: store.getState(),
                });

                return Promise.resolve({
                    type: MessageType.GetFullStateResponse,
                    payload: store.getState(),
                });
```